### PR TITLE
🐛 Fix podcasts appearing in the "Writing" list

### DIFF
--- a/lib/combined_rss_feed.rb
+++ b/lib/combined_rss_feed.rb
@@ -1,5 +1,9 @@
 require "rss_feed"
 
+class Feedjira::Parser::ITunesRSSItem
+  element "thoughtbot:auto_social_share", as: :auto_social_share
+end
+
 class CombinedRssFeed
   include Enumerable
 

--- a/lib/rss_feed.rb
+++ b/lib/rss_feed.rb
@@ -4,6 +4,10 @@ require "feedjira"
 
 require "feed_item"
 
+class Feedjira::Parser::AtomEntry
+  element "thoughtbot:auto_social_share", as: :auto_social_share
+end
+
 class RssFeed
   include Enumerable
 
@@ -12,7 +16,7 @@ class RssFeed
   end
 
   def each
-    feed.entries.each do |entry|
+    feed.entries.reject { it.auto_social_share == "false" }.each do |entry|
       yield FeedItem.new(
         id: entry.id,
         title: entry.title,

--- a/spec/rss_feed_spec.rb
+++ b/spec/rss_feed_spec.rb
@@ -29,6 +29,58 @@ RSpec.describe RssFeed do
       )
     end
 
+    it "ignores entries we don't automatically share to social media" do
+      Excon.stub({}, {status: 200, body: <<~XML.chomp})
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>TEST_FEED_TITLE</title>
+          <subtitle>TEST_SUBTITLE</subtitle>
+          <id>https://example.com/</id>
+          <link href="https://example.com/blog"/>
+          <link href="https://example.com/blog/feed.xml" rel="self"/>
+          <updated>2024-12-20T00:00:00+00:00</updated>
+          <author>
+            <name>TEST_NAME</name>
+          </author>
+          <entry>
+            <title>TEST_ENTRY_1</title>
+            <link rel="alternate" href="https://example.com/test-entry-1"/>
+            <author>
+              <name>TEST_AUTHOR</name>
+            </author>
+            <id>https://example.com/test-entry-1</id>
+            <published>2025-05-22T00:00:00+00:00</published>
+            <updated>2025-05-22T12:40:11Z</updated>
+            <content type="html">
+              <![CDATA[TEST_CONTENT]]>
+            </content>
+            <summary>TEST_SUMMARY</summary>
+            <thoughtbot:auto_social_share>false</thoughtbot:auto_social_share>
+          </entry>
+          <entry>
+            <title>TEST_ENTRY_2</title>
+            <link rel="alternate" href="https://example.com/test-entry-2"/>
+            <author>
+              <name>TEST_AUTHOR</name>
+            </author>
+            <id>https://example.com/test-entry-2</id>
+            <published>2025-05-29T00:00:00+00:00</published>
+            <updated>2025-05-29T12:40:11Z</updated>
+            <content type="html">
+              <![CDATA[TEST_CONTENT]]>
+            </content>
+            <summary>TEST_SUMMARY</summary>
+            <thoughtbot:auto_social_share>true</thoughtbot:auto_social_share>
+          </entry>
+        </feed>
+      XML
+      rss_feed = RssFeed.new url: "https://example.com/blog/feed.xml"
+
+      entries_titles = rss_feed.map(&:title)
+
+      expect(entries_titles).to contain_exactly "TEST_ENTRY_2"
+    end
+
     def atom_feed
       File.read("spec/fixtures/rss_feed.xml")
     end


### PR DESCRIPTION
Before, podcast episodes appeared in both the "Writing" and "Podcasts" lists. There was no need for this duplication, and we wanted to highlight more of our content. We fixed the list only to include items where we've marked `auto_social_share` as false.

[Trello](https://trello.com/c/2CIy3mOR)
